### PR TITLE
17 tf alias for terraform

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,11 +3,13 @@ tasks:
     before: |
       source ./bin/install_terraform_cli.sh
       source ./bin/generate_tfrc_credentials.sh
+      source ./bin/set_tf_alias.sh
   - name: aws-cli
     env:
       AWS_CLI_AUTO_PROMPT: on-partial
     before: |
       source ./bin/install_aws_cli.sh
+      source ./bin/set_tf_alias.sh
 vscode:
   extensions:
     - amazonwebservices.aws-toolkit-vscode

--- a/README.md
+++ b/README.md
@@ -290,3 +290,9 @@ Script checks if env var TERRAFORM_CLOUD_TOKEN is set in gitpod and if it is scr
 Bash script used to achive this [generate_tfrc_credentials.sh](./bin/generate_tfrc_credentials.sh)
 
 I have also made the script executable and sourced it in [.gitpod.yml](.gitpod.yml) and I added TERRAFORM_CLOUD_TOKEN as global gitpod env var, A.k.a gitpod secret.
+
+### TF as alias for Terraform
+
+To be quicker on the command line I have set `tf` as an alias for `terraform` command, and I have also enabled terraform autocompletion in bash for both `tf` and `terraform` command.
+
+This is automatically configured on gitpod startup with a scitp [set_tf_alias.sh](./bin/set_tf_alias.sh)

--- a/bin/set_tf_alias.sh
+++ b/bin/set_tf_alias.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Check if alias already exists in the .bash_profile
+grep -q 'alias tf="terraform"' ~/.bash_profile
+
+if [ $? -ne 0 ]; then
+  # If the alias does not exists, appent it
+  echo 'alias tf="terraform"' >> ~/.bash_profile
+  echo "Alias added succesfully"
+else
+  # Inform the user that alias already exists
+  echo "Alias already exists in .bash_profile"
+fi
+
+# Check is terraform autocompletion enable in the .bash_profile
+grep -q 'complete -C /usr/bin/terraform terraform' ~/.bash_profile
+
+if [ $? -ne 0 ]; then
+  # If the alias does not exists, appent it
+  echo 'complete -C /usr/bin/terraform terraform' >> ~/.bash_profile
+  echo "Terraform autocompletion enabled"
+else
+  # Inform the user that alias already exists
+  echo "Terraform autocompletion was already enabled in .bash_profile"
+fi
+
+# Check is terraform autocompletion for alias tf enable in the .bash_profile
+grep -q 'complete -C /usr/bin/terraform tf' ~/.bash_profile
+
+if [ $? -ne 0 ]; then
+  # If the alias does not exists, appent it
+  echo 'complete -C /usr/bin/terraform tf' >> ~/.bash_profile
+  echo "Terraform autocompletion for alias tf enabled"
+else
+  # Inform the user that alias already exists
+  echo "Terraform autocompletion for alias tf was already enabled in .bash_profile"
+fi
+
+# Source the .bash_profile to make the alias and autocompletion available immediatly
+source ~/.bash_profile

--- a/bin/set_tf_alias.sh
+++ b/bin/set_tf_alias.sh
@@ -6,10 +6,10 @@ grep -q 'alias tf="terraform"' ~/.bash_profile
 if [ $? -ne 0 ]; then
   # If the alias does not exists, appent it
   echo 'alias tf="terraform"' >> ~/.bash_profile
-  echo "Alias added succesfully"
+  echo "Alias tf added succesfully"
 else
   # Inform the user that alias already exists
-  echo "Alias already exists in .bash_profile"
+  echo "Alias tf already exists in .bash_profile"
 fi
 
 # Check is terraform autocompletion enable in the .bash_profile


### PR DESCRIPTION
Created set_tf_alias.sh script that set tf as an alias for terraform command.
Also enabled terraform bash autocompletion for both terraform and tf commands